### PR TITLE
fix compilation error for eeprom

### DIFF
--- a/eepromer/eeprom.c
+++ b/eepromer/eeprom.c
@@ -13,6 +13,7 @@ Downloaded from http://www.lm-sensors.org/browser/i2c-tools/trunk/eepromer/eepro
 #include <fcntl.h>
 #include <string.h>
 #include <time.h>
+#include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 
 /*


### PR DESCRIPTION
# include <linux/i2c.h> was removed, but it causes compilation error :

<builtin>: recipe for target 'eeprom.o' failed
make: **\* [eeprom.o] Error 1
